### PR TITLE
Create mdbook.yml

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -1,0 +1,60 @@
+# Sample workflow for building and deploying a mdBook site to GitHub Pages
+#
+# To get started with mdBook see: https://rust-lang.github.io/mdBook/index.html
+#
+name: Deploy mdBook site to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["master"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    env:
+      MDBOOK_VERSION: 0.4.36
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install mdBook
+        run: |
+          curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf -y | sh
+          rustup update
+          cargo install --version ${MDBOOK_VERSION} mdbook
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v5
+      - name: Build with mdBook
+        run: mdbook build
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./book
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the building and deployment of an `mdBook` site to GitHub Pages. The workflow ensures efficient deployment with proper permissions, concurrency handling, and a two-step process for building and deploying the site.

### New GitHub Actions Workflow for `mdBook` Deployment:
* **Workflow Setup**: Added a new workflow file `.github/workflows/mdbook.yml` to build and deploy an `mdBook` site. The workflow triggers on pushes to the `master` branch and supports manual dispatch.
* **Build Job**:
  - Installs the specified version of `mdBook` (`0.4.36`) using Rust's package manager.
  - Configures the Pages environment and builds the site using `mdBook`.
  - Uploads the generated site as an artifact for deployment.
* **Deployment Job**:
  - Deploys the built site to GitHub Pages using the `actions/deploy-pages` action.
  - Configures the environment and URL for the deployed site.
* **Concurrency Management**: Ensures only one deployment runs at a time, skipping queued runs but allowing in-progress runs to complete.